### PR TITLE
Update Grafana default password in README & Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o ollama-metrics .
 FROM scratch
 
 # Copy the binary from builder
-COPY --from=builder /app/main /main
+#COPY --from=builder /app/main /main
+COPY --from=builder /app/ollama-metrics /ollama-metrics
 
 # Command to run
 ENTRYPOINT ["/ollama-metrics"]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will start:
 - Prometheus for metrics collection
 - Grafana with pre-configured dashboard
 
-Access Grafana at http://localhost:3000 (default credentials: admin/admin)
+Access Grafana at http://localhost:3000 (default credentials: admin/password)
 
 ## Building from Source
 


### PR DESCRIPTION
This pull request updates the build and deployment process for the project, mainly focusing on the Docker setup and documentation. The most important changes include updating the Go version in the Dockerfile, correcting the binary copy step, and updating default credentials in the documentation.

**Dockerfile improvements:**

* Updated the base Go image from `golang:1.23-alpine` to `golang:1.24-alpine` to use the latest Go version for building the application.
* Fixed the binary copy step to copy the correct output binary (`ollama-metrics`) from the build stage, instead of the previously referenced `main`.

**Documentation update:**

* Changed the default Grafana credentials in `README.md` from `admin/admin` to `admin/password` to reflect the updated setup.