### PR TITLE
fix(go.mod): drop accidental /m/v2 suffix from module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/NorskHelsenett/ollama-metrics/m/v2
+module github.com/NorskHelsenett/ollama-metrics
 
 go 1.24.2
 


### PR DESCRIPTION
The module declaration says `github.com/NorskHelsenett/ollama-metrics/m/v2` but the repo lives at `github.com/NorskHelsenett/ollama-metrics`. The `/m/v2` suffix is the artifact `go mod init` produces when run with no arguments inside an empty directory; it was never the intended import path.

## Effect on consumers

The Go module proxy refuses every commit on the canonical path because it sees the canonical-vs-declared mismatch:

```
go: github.com/NorskHelsenett/ollama-metrics@main:
  github.com/NorskHelsenett/ollama-metrics@v0.0.0-...:
  invalid version: go.mod has post-v0 module path
  "github.com/NorskHelsenett/ollama-metrics/m/v2" at revision ...
```

So `go install github.com/NorskHelsenett/ollama-metrics@latest` fails, and downstream packagers (Ansible roles, Helm charts that build the exporter as a sidecar, etc.) have to fall back to `git clone` + local `go build` workarounds.

## Fix

One line: drop the `/m/v2` suffix so the module declaration matches the canonical repo path.

```diff
-module github.com/NorskHelsenett/ollama-metrics/m/v2
+module github.com/NorskHelsenett/ollama-metrics
```

## Verification

- `go mod tidy` is a no-op after the fix (no `go.sum` changes).
- `go build .` produces a working binary.
- No internal imports referenced the old path (`grep -r ollama-metrics/m/v2` finds zero hits outside `go.mod`).

(Replaces #6 — that PR was opened from a personal-account fork; reopened here from the org-owned fork for proper attribution.)